### PR TITLE
basic auth implemented

### DIFF
--- a/citrus_network/citrus_home/views.py
+++ b/citrus_network/citrus_home/views.py
@@ -34,7 +34,7 @@ def basicAuthHandler(request):
 
         credentials = base64.b64decode(credentials)
         username, password = credentials.decode('utf-8').split(':')
-        if username == "CitrusNetwork" and password == "oranges":
+        if username == "CitrusNetwork" and password == "oranges" and token_type == "Basic":
             return True
         return False
     except:


### PR DESCRIPTION
Basic Auth Handler is implemented and I made service/authors API call use it. If you want to test it out, try running this curl command (our username is "CitrusNetwork" and our password is "oranges"):

curl -H "Authorization:Basic $(echo -n CitrusNetwork:oranges | base64)" -v http://127.0.0.1:8000/service/authors/

Try changing either username or password and it won't work anymore. This needs to be applied to back end API calls which other nodes will be connecting to us with, and all of our API calls need to be refactored to have this header implemented.

Please note:
The username:password string must be base64 encoded