### PR TITLE
Require Server Admin OK to finally be on the server

### DIFF
--- a/citrus_network/citrus_home/admin.py
+++ b/citrus_network/citrus_home/admin.py
@@ -9,7 +9,23 @@ class CitrusAuthorAdmin(admin.ModelAdmin):
 #     list_display = ('id', 'title', 'description', 'content', 'author', 'commonmark', 'visibility',)
 
 class PostAdmin(admin.ModelAdmin):
-    list_display = ('id','title','description','content','author','origin','contentType','categories','visibility','created' )
+    list_display = ('type',
+                    'title',
+                    'id',
+                    'source',
+                    'origin',
+                    'description',
+                    'contentType',
+                    'content',
+                    'author',
+                    'categories',
+                    'count',
+                    'size',
+                    'comments',
+                    'published',
+                    'visibility',
+                    'unlisted',
+                    'shared_with')
 
 
 class CommentAdmin(admin.ModelAdmin):

--- a/citrus_network/citrus_home/models.py
+++ b/citrus_network/citrus_home/models.py
@@ -3,6 +3,16 @@ import uuid
 from django.contrib.auth.models import User
 from django.core.validators import int_list_validator
 from django.urls import reverse
+from django.dispatch import receiver
+from django.db.models.signals import pre_save
+
+@receiver(pre_save, sender=User)
+def set_new_user_inactive(sender, instance, **kwargs):
+    if instance._state.adding is True:
+        print("Creating Inactive User")
+        instance.is_active = False
+    else:
+        print("Updating User Record")
 
 CONTENT_TYPE = {
     ('text/plain', 'Plain Text'),

--- a/citrus_network/citrus_home/models.py
+++ b/citrus_network/citrus_home/models.py
@@ -37,24 +37,35 @@ common_mark = markdown
 posts have different types: public, shared to friends, private to author, private to friends
 """
 class Post(models.Model):
-    id                  = models.CharField(max_length=50, primary_key=True)
+    type                = models.CharField(max_length=50, default='post')
+    # title of a post
     title               = models.CharField(max_length=200)
+    # id of the post
+    id                  = models.CharField(max_length=50, primary_key=True)
+    # where did you get this post from?
+    source              = models.CharField(max_length=300)
+    # where is it actually from
+    origin              = models.CharField(max_length=300)
+    # a brief description of the post
     description         = models.CharField(max_length=300, null=True, blank=True)
+    contentType         = models.CharField(max_length=20, default='text/plain', choices=CONTENT_TYPE)
     content             = models.TextField()
     author              = models.ForeignKey(CitrusAuthor, on_delete=models.CASCADE)
-    origin              = models.CharField(max_length=300)
-    contentType         = models.CharField(max_length=20, default='text/plain', choices=CONTENT_TYPE)
-    # commonmark          = models.BooleanField(default=False)
-    # image           = models.ImageField()
     # parse this and return as list for GET request
     categories          = models.CharField(max_length=400, null=True, blank=True)
+    # total number of comments for this post
+    count               = models.IntegerField(null=True, blank=True)
+    # page size
+    size                = models.IntegerField(null=True, blank=True)
+    # the first page of comments
+    comments            = models.CharField(max_length=300, null=True, blank=True)
+    published           = models.DateTimeField(auto_now_add=True)
     # if visibility option is not provided the default will be public
     visibility          = models.CharField(max_length=50, choices=VISIBILITY_CHOICES, default="PUBLIC")
+    # unlisted means it is public if you know the post name -- use this for images, it's so images don't show up in timelines
+    unlisted            = models.BooleanField(default=False)
     # if private to author or private to friends is true add usernames to shared_with
     shared_with         = models.CharField(max_length=600, null=True, blank=True)
-    created             = models.DateTimeField(auto_now_add=True)
-
-
 
 """
 a comment will belong to an author and also be associated with one post

--- a/citrus_network/citrus_home/models.py
+++ b/citrus_network/citrus_home/models.py
@@ -3,16 +3,8 @@ import uuid
 from django.contrib.auth.models import User
 from django.core.validators import int_list_validator
 from django.urls import reverse
-from django.dispatch import receiver
-from django.db.models.signals import pre_save
-
-@receiver(pre_save, sender=User)
-def set_new_user_inactive(sender, instance, **kwargs):
-    if instance._state.adding is True:
-        print("Creating Inactive User")
-        instance.is_active = False
-    else:
-        print("Updating User Record")
+# from django.dispatch import receiver
+# from django.db.models.signals import pre_save
 
 CONTENT_TYPE = {
     ('text/plain', 'Plain Text'),

--- a/citrus_network/citrus_home/views.py
+++ b/citrus_network/citrus_home/views.py
@@ -95,7 +95,9 @@ def register_redirect(request):
         form = UserCreationForm(request.POST)
         if form.is_valid():
             # creates the user object
-            user = form.save()
+            user = form.save(commit=False)
+            user.is_active = False
+            user.save()
             # login with newly created user
             username = request.POST.get('username')
             password = request.POST.get('password')

--- a/citrus_network/citrus_home/views.py
+++ b/citrus_network/citrus_home/views.py
@@ -983,7 +983,17 @@ def make_post_redirect(request):
             categories = str(request.POST['categories'])
             visibility = str(request.POST['visibility'])
             shared_with = str(request.POST['shared_with'])
-            post = Post.objects.create(id=post_id, title=title, description=description, content=content, contentType=contentType, categories=categories, author=author, origin=str(request.headers['Origin']), visibility=visibility, shared_with=shared_with)
+            post = Post.objects.create(id=post_id, 
+                                    title=title, 
+                                    description=description, 
+                                    content=content, 
+                                    contentType=contentType, 
+                                    categories=categories, 
+                                    author=author, 
+                                    origin=str(request.headers['Origin']), 
+                                    source=str(request.headers['Origin']), 
+                                    visibility=visibility, 
+                                    shared_with=shared_with)
             return redirect(home_redirect)
         else:
             data = form.errors.as_json()
@@ -1096,7 +1106,17 @@ def manage_post(request, id, **kwargs):
         #
         body = json.loads(request.body)
         author = CitrusAuthor.objects.get(id=id)
-        post = Post.objects.create(id=str(uuid.uuid4()), title=body['title'], description=body['description'],content=body['content'],contentType=body['contentType'], categories=body['categories'], author=author, origin=body['origin'], visibility=body['visibility'], shared_with=body['shared_with'])
+        post = Post.objects.create(id=str(uuid.uuid4()), 
+                                title=body['title'], 
+                                description=body['description'],
+                                content=body['content'],
+                                contentType=body['contentType'],
+                                categories=body['categories'],
+                                author=author,
+                                origin=body['origin'],
+                                source=body['origin'],
+                                visibility=body['visibility'],
+                                shared_with=body['shared_with'])
         return returnJsonResponse(specific_message="post created", status_code=201)
 
     
@@ -1156,7 +1176,7 @@ def manage_post(request, id, **kwargs):
             "type": "post",
             "title": posts.title,
             "id": posts.id,
-            "source": "localhost:8000/some_random_source",
+            "source": posts.source,
             "origin": posts.origin,
             "description": posts.description,
             "contentType": posts.contentType,
@@ -1166,7 +1186,7 @@ def manage_post(request, id, **kwargs):
             "categories": categories,
             "count": comments.count(),
             "comments": comments_arr, 
-            "published": posts.created,
+            "published": posts.published,
             "visibility": posts.visibility,
             "unlisted": "false"
         }
@@ -1298,7 +1318,7 @@ def handleStream(request):
             posts_arr = []
             visibility_list=['PUBLIC', 'PRIVATE_TO_FRIENDS']
             # for now we are only looking for public posts this will later be extended to private to author and private to friends
-            posts = Post.objects.filter(author__in=friends_arr,visibility__in=visibility_list).order_by('-created')
+            posts = Post.objects.filter(author__in=friends_arr,visibility__in=visibility_list).order_by('-published')
             json_posts = []
             for post in posts:
                 author = post.author
@@ -1320,7 +1340,7 @@ def handleStream(request):
                     "categories": categories,
                     "count": comments.count(),
                     "comments": comments_arr, 
-                    "published": post.created,
+                    "published": post.published,
                     "visibility": post.visibility,
                     "unlisted": "false"
                 }
@@ -1337,7 +1357,7 @@ def handleStream(request):
                 posts_arr = []
                 # for now we are only looking for public posts this will later be extended to private to author and private to friends
                 visibility_list=['PUBLIC']
-                posts = Post.objects.filter(author__in=friends_arr,visibility__in=visibility_list).order_by('-created')
+                posts = Post.objects.filter(author__in=friends_arr,visibility__in=visibility_list).order_by('-published')
                 json_posts = []
                 for post in posts:
                     author = post.author
@@ -1359,7 +1379,7 @@ def handleStream(request):
                         "categories": categories,
                         "count": comments.count(),
                         "comments": comments_arr, 
-                        "published": post.created,
+                        "published": post.published,
                         "visibility": post.visibility,
                         "unlisted": "false"
                     }


### PR DESCRIPTION
- Implemented this: "As a server admin, I want to OPTIONALLY be able allow users to sign up but require my OK to finally be on my server". User must be approved by server admin before they can use Citrus Network.
- Fix some fields in the post api to match spec. 